### PR TITLE
CLProgram.updateKernels() crash fixed on Mac OS X

### DIFF
--- a/source/dcl/program.d
+++ b/source/dcl/program.d
@@ -79,6 +79,14 @@ protected:
         //kernels.clear;
         kernels = null;
 
+        // clGetProgramInfo crashes on OSX when querying CL_PROGRAM_KERNEL_NAMES
+        // before a program is built. Here's a workaround for that.
+        version( OSX )
+        {
+            immutable hasValidInfo = any!( (a) => a.status == BuildStatus.SUCCESS )( buildInfo() );
+            if( !hasValidInfo ) return;
+        }
+
         // by standart clGetProgramInfo returns
         // CL_INVALID_PROGRAM_EXECUTABLE if param_name is
         // CL_PROGRAM_NUM_KERNELS or CL_PROGRAM_KERNEL_NAMES


### PR DESCRIPTION
Building a simple OpenCL program on OS X ends with a crash in CLProgram.updateKernels(). Here's my test code

```
import dcl.base;
import dcl.platform;
import dcl.device;
import dcl.context;
import dcl.program;

void main() {
    loadCL();

    auto platform = CLPlatform.getAll()[0];
    auto context = new CLContext(platform, CLDevice.Type.GPU);
    auto src = "kernel void HelloThere(global int *ptr) {}";
    auto program = context.buildProgram(src);
}
```

And the callstack

 ```
lldb helloworld
(lldb) target create "helloworld"
Current executable set to 'helloworld' (x86_64).
(lldb) r
Process 886 launched: '/Users/mateuszsadel/Desktop/ocl/helloworld/helloworld' (x86_64)
Process 886 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x00007fff32864d3e CoreFoundation`CFArrayGetCount + 10
CoreFoundation`CFArrayGetCount:
->  0x7fff32864d3e <+10>: movq   (%rdi), %rax
    0x7fff32864d41 <+13>: testq  %rax, %rax
    0x7fff32864d44 <+16>: je     0x7fff32864d71            ; <+61>
    0x7fff32864d46 <+18>: leaq   0x58b9b643(%rip), %rcx    ; __CFConstantStringClassReferencePtr
Target 0: (helloworld) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
  * frame #0: 0x00007fff32864d3e CoreFoundation`CFArrayGetCount + 10
    frame #1: 0x00007fff328ee7ad CoreFoundation`CFStringCreateByCombiningStrings + 34
    frame #2: 0x00007fff3b44cfc2 OpenCL`clGetProgramInfo + 181
    frame #3: 0x000000010004a6b7 helloworld`_D3dcl4base__T9checkCallS_D8derelict6opencl9functions16clGetProgramInfoPUNbPvkmQePmZiVAyaa67_2e2e2f2e2e2f2e2e2f2e6475622f7061636b616765732f64636c2d302e362e302f64636c2f736f757263652f64636c2f70726f6772616d2e642d6d6978696e2d323034Vmi297TQGdTiTiTnTQGhZQJaFQGviiQpQGwZv at base.d:151
    frame #4: 0x0000000100057d9b helloworld`_D3dcl7program9CLProgram12kernel_namesMFNdZAya at program.d-mixin-204:297
    frame #5: 0x0000000100057528 helloworld`_D3dcl7program9CLProgram13updateKernelsMFZv at program.d:88
    frame #6: 0x000000010005732e helloworld`_D3dcl7program9CLProgram10updateInfoMFZv at program.d:46
    frame #7: 0x0000000100057241 helloworld`_D3dcl7program9CLProgram6__ctorMFPvZCQBjQBiQBd at program.d:38
    frame #8: 0x000000010005778a helloworld`_D3dcl7program9CLProgram9getFromIDFPvZCQBlQBkQBf at program.d:118
    frame #9: 0x00000001000578db helloworld`_D3dcl7program9CLProgram16createWithSourceFCQBq7context9CLContextAyaZCQCqQCpQCk at program.d:141
    frame #10: 0x000000010004c014 helloworld`_D3dcl7context9CLContext12buildProgramMFAyaACQBr7program13CLBuildOptionZCQCtQBc9CLProgram at context.d:131
    frame #11: 0x0000000100000a62 helloworld`_Dmain at app.d:15
    frame #12: 0x000000010007d518 helloworld`_D2rt6dmain211_d_run_mainUiPPaPUAAaZiZ6runAllMFZ9__lambda1MFZv + 40
    frame #13: 0x000000010007d3a8 helloworld`_D2rt6dmain211_d_run_mainUiPPaPUAAaZiZ7tryExecMFMDFZvZv + 32
    frame #14: 0x000000010007d483 helloworld`_D2rt6dmain211_d_run_mainUiPPaPUAAaZiZ6runAllMFZv + 139
    frame #15: 0x000000010007d3a8 helloworld`_D2rt6dmain211_d_run_mainUiPPaPUAAaZiZ7tryExecMFMDFZvZv + 32
    frame #16: 0x000000010007d30f helloworld`_d_run_main + 663
    frame #17: 0x0000000100000a92 helloworld`main + 34
    frame #18: 0x00007fff5fad8ed9 libdyld.dylib`start + 1
    frame #19: 0x00007fff5fad8ed9 libdyld.dylib`start + 1
```

Apparently OS X has a problem with clGetProgramInfo() with CL_PROGRAM_KERNEL_NAMES when we don't have an executable built. OpenCL docs say the result is available when we have a program executable built. Well, CLProgram.updateKernel() runs before build() method so we have a crash.